### PR TITLE
Fix USB device intents for SDK34+

### DIFF
--- a/libuvccamera/build.gradle
+++ b/libuvccamera/build.gradle
@@ -34,7 +34,7 @@ android {
 	}
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 19
 		targetSdkVersion versionTarget
     }
 

--- a/libuvccamera/build.gradle
+++ b/libuvccamera/build.gradle
@@ -65,7 +65,8 @@ dependencies {
     implementation fileTree(dir: new File(buildDir, 'libs'), include: '*.jar')
 
 	implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-	implementation 'androidx.annotation:annotation:1.6.0'
+	implementation 'androidx.core:core:1.13.1'
+	implementation 'androidx.annotation:annotation:1.8.2'
 
 	implementation("com.serenegiant:common:${commonLibVersion}") {
 		exclude module: 'support-v4'

--- a/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/libuvccamera/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -49,6 +49,9 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.util.SparseArray;
 
+import androidx.core.app.PendingIntentCompat;
+import androidx.core.content.ContextCompat;
+
 import com.serenegiant.utils.HandlerThreadHandler;
 
 public final class USBMonitor {
@@ -167,15 +170,13 @@ public final class USBMonitor {
 			if (DEBUG) Log.i(TAG, "register:");
 			final Context context = mWeakContext.get();
 			if (context != null) {
-				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-					mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_MUTABLE);
-				} else {
-					mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), 0);
-				}
+				Intent intent = new Intent(ACTION_USB_PERMISSION);
+				intent.setPackage(context.getPackageName());
+				mPermissionIntent = PendingIntentCompat.getBroadcast(context, 0, intent, 0, true);
 				final IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
 				// ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
 				filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-				context.registerReceiver(mUsbReceiver, filter);
+				ContextCompat.registerReceiver(context, mUsbReceiver, filter, ContextCompat.RECEIVER_EXPORTED);
 			}
 			// start connection check
 			mDeviceCounts = 0;

--- a/usbCameraCommon/build.gradle
+++ b/usbCameraCommon/build.gradle
@@ -34,7 +34,7 @@ android {
    	}
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 19
         targetSdkVersion versionTarget
 
     }


### PR DESCRIPTION
This should fix

> Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.

